### PR TITLE
Update probe.py

### DIFF
--- a/probe.py
+++ b/probe.py
@@ -60,7 +60,13 @@ def ffprobe_cmd(params):
         raw_output = out.decode("utf-8")
     except Exception as e:
         raise FFProbeError(command, str(e))
-    if pipe.returncode == 1 or 'error' in raw_output:
+
+    if 'error' in raw_output:
+        try:
+            info = json.loads(raw_output)
+        except Exception as e:
+            raise FFProbeError(command, raw_output)
+    if pipe.returncode == 1:
         raise FFProbeError(command, raw_output)
     if not raw_output:
         raise FFProbeError(command, 'No info found')


### PR DESCRIPTION
ffprobe_cmd checks for "error" in raw_output.  but if source is an mp4 file it could have mov_text subtitles, so checking raw_output could have the string "error" in a word in a subtitle.  So, this PR presumes that if the word is only in the subtitle text than it will still load json and if it does that, then the error is likely not an issue.  Otherwise if the json doesn't load, then raise FFProbeError.