### PR TITLE
Pr stream mapper.py

### DIFF
--- a/probe.py
+++ b/probe.py
@@ -60,7 +60,13 @@ def ffprobe_cmd(params):
         raw_output = out.decode("utf-8")
     except Exception as e:
         raise FFProbeError(command, str(e))
-    if pipe.returncode == 1 or 'error' in raw_output:
+
+    if 'error' in raw_output:
+        try:
+            info = json.loads(raw_output)
+        except Exception as e:
+            raise FFProbeError(command, raw_output)
+    if pipe.returncode == 1:
         raise FFProbeError(command, raw_output)
     if not raw_output:
         raise FFProbeError(command, 'No info found')

--- a/stream_mapper.py
+++ b/stream_mapper.py
@@ -233,8 +233,19 @@ class StreamMapper(object):
                         self.audio_stream_count += 1
                         continue
                 else:
-                    self.__copy_stream_mapping('a', self.audio_stream_count)
-                    self.audio_stream_count += 1
+                    if self.settings.get_setting('mode') == 'advanced':
+                        amaps = self.settings.get_setting('custom_options').split()
+                        self.logger.debug("Advanced Mode Video Settings with custom audio encoding: '%s'", amaps)
+                        if '-c:a' not in amaps:
+                            self.logger.debug("-c:a not detected in custom mappings: '%s'", amaps)
+                            self.__copy_stream_mapping('a', self.audio_stream_count)
+                        else:
+                            self.logger.debug("-c:a detected in custom mappings: '%s'", amaps)
+                            self.stream_mapping += ['-map', '0:{}:{}'.format('a', self.audio_stream_count)]
+                        self.audio_stream_count += 1
+                    else:
+                        self.__copy_stream_mapping('a', self.audio_stream_count)
+                        self.audio_stream_count += 1
                     continue
 
             # If this is a subtitle stream?
@@ -255,8 +266,19 @@ class StreamMapper(object):
                         self.subtitle_stream_count += 1
                         continue
                 else:
-                    self.__copy_stream_mapping('s', self.subtitle_stream_count)
-                    self.subtitle_stream_count += 1
+                    if self.settings.get_setting('mode') == 'advanced':
+                        submaps = self.settings.get_setting('custom_options').split()
+                        self.logger.debug("Advanced Mode Video Settings with custom subtitle encoding: '%s'", submaps)
+                        if '-c:s' not in submaps:
+                            self.logger.debug("-c:s not detected in custom mappings: '%s'", submaps)
+                            self.__copy_stream_mapping('s', self.subtitle_stream_count)
+                        else:
+                            self.logger.debug("-c:s detected in custom mappings: '%s'", submaps)
+                            self.stream_mapping += ['-map', '0:{}:{}'.format('s', self.subtitle_stream_count)]
+                        self.subtitle_stream_count += 1
+                    else:
+                        self.__copy_stream_mapping('s', self.subtitle_stream_count)
+                        self.subtitle_stream_count += 1
                     continue
 
             # If this is a data stream?


### PR DESCRIPTION
modified stream_mapper.py to allow for subtitle and audio encoder options to be specified in custom options when using advanced mode.  This is helpful when processing video files and simultaneously wishing to encode audio &/or subtitle stream at the same time rather than simply copying them.