### PR TITLE
Enable calculating progress when no frame= found in ffmpeg progress message

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -97,7 +97,7 @@ class Parser(object):
         :return:
         """
         # Fetch data from line text
-        if line_text and 'frame=' in line_text:
+        if line_text and ('frame=' in line_text or 'time=' in line_text):
             # Update time
             _time = self.get_progress_from_regex_of_string(line_text, r"time=(\s+|)(\d+:\d+:\d+\.\d+)", self.time)
             if _time:


### PR DESCRIPTION
### Context

The code already exists to attempt to calculate the progress of a command using the `time=` value in the ffmpeg output, but it's not accounted for in the conditional block.

This is immediately relevant for the `extract_srt_subtitles_to_files` plugin, which doesn't output the frame number. A [draft PR is open](https://github.com/Unmanic/unmanic-plugins/pull/376) for that plugin to update to the latest version of this helper (submodule commit number will need to be updated once this PR is merged).

### Implementation

- Update the if statement in the `parser.parse_progress` function to allow calculating progress when _either_ `frame` or `time` values are present in the ffmpeg progress output
- The `parse_progress` function will still attempt to use the `frame` value before trying the `time` value, but this will enable calculating progress for commands that don't include a `frame` value - eg. extracting srt files
- Tested working locally for the `extract_srt_subtitles_to_files` plugin